### PR TITLE
added logic to only allow one appklication perdog for the same adopter

### DIFF
--- a/pittyapi/views/application.py
+++ b/pittyapi/views/application.py
@@ -25,6 +25,21 @@ class ApplicationViewSet(viewsets.ModelViewSet):
     serializer_class = ApplicationSerializer
 
     def create(self, request, *args, **kwargs):
+        dog_id = request.data.get("dog")
+        adopter_id = request.data.get("adopter")
+
+        # Check if an application already exists for this dog and adopter
+        existing_application = Application.objects.filter(
+            dog_id=dog_id, adopter_id=adopter_id
+        ).first()
+
+        if existing_application:
+            return Response(
+                {"error": "An application already exists for this dog and adopter."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Proceed with creating a new application if none exists
         response = super().create(request, *args, **kwargs)
         return Response(response.data, status=status.HTTP_201_CREATED)
 

--- a/pittyproject/settings.py
+++ b/pittyproject/settings.py
@@ -12,6 +12,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", get_random_secret_key())
 DEBUG = os.getenv("DEBUG", "False")
+# ALLOWED_HOSTS = ["127.0.0.1", "localhost", ""]
 ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "").split(",")
 DEVELOPMENT_MODE = os.getenv("DEVELOPMENT_MODE", "False")
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")


### PR DESCRIPTION
added logioc to application view to only allow one application for a dog by the adopter
 ``` def create(self, request, *args, **kwargs):
        dog_id = request.data.get("dog")
        adopter_id = request.data.get("adopter")

        # Check if an application already exists for this dog and adopter
        existing_application = Application.objects.filter(
            dog_id=dog_id, adopter_id=adopter_id
        ).first()

        if existing_application:
            return Response(
                {"error": "An application already exists for this dog and adopter."},
                status=status.HTTP_400_BAD_REQUEST,
            )

        # Proceed with creating a new application if none exists
        response = super().create(request, *args, **kwargs)
        return Response(response.data, status=status.HTTP_201_CREATED)